### PR TITLE
Typed Properties

### DIFF
--- a/sample/src/App.fs
+++ b/sample/src/App.fs
@@ -159,7 +159,7 @@ let view model dispatch =
 
         {toggleVisible "Clock" model.ShowClock (fun () -> dispatch ToggleClock)}
         {if not model.ShowClock then Lit.nothing
-         else html $"<my-clock hour-color=\"yellow\"></my-clock>"}
+         else html $"<my-clock hour-color=\"yellow\" .reactiveProp={model.ShowReact}></my-clock>"}
 
         {elmishNameInput model.Value (ChangeValue >> dispatch)}
         {LocalNameInput()}

--- a/sample/src/App.fs
+++ b/sample/src/App.fs
@@ -183,7 +183,7 @@ let view model dispatch =
         {if model.ShowReact then ReactLitComponent model.ShowClock else Lit.nothing}
 
         <!--{buttonFeliz model dispatch}-->
-        <my-clock hour-color="red"></my-clock>
+        <my-clock></my-clock>
 
         {nameInput model.Value (ChangeValue >> dispatch)}
         {NameInput()}

--- a/sample/src/App.fs
+++ b/sample/src/App.fs
@@ -183,7 +183,7 @@ let view model dispatch =
         {if model.ShowReact then ReactLitComponent model.ShowClock else Lit.nothing}
 
         <!--{buttonFeliz model dispatch}-->
-        <my-clock hourColor="red"></my-clock>
+        <my-clock hour-color="red"></my-clock>
 
         {nameInput model.Value (ChangeValue >> dispatch)}
         {NameInput()}

--- a/sample/src/Clock.fs
+++ b/sample/src/Clock.fs
@@ -97,6 +97,7 @@ let initEl (config: LitConfig<_>) =
     config.props <-
         {|
             hourColor = Prop.Of("lightgreen", attribute="hour-color")
+            reactiveProp = Prop.Of(true)
         |}
 
     config.styles <- [
@@ -123,6 +124,7 @@ let initEl (config: LitConfig<_>) =
 let Clock() =
     let props = LitElement.init initEl
     let hourColor = props.hourColor.Value
+    let reactiveProp = props.reactiveProp.Value
 
     let model, dispatch = Hook.useElmish(init, update)
     let time = model.CurrentTime
@@ -152,6 +154,7 @@ let Clock() =
 
         <div class="container">
             <p>This is a clock</p>
+            <p>React is {if reactiveProp then "On" else "Off"} </p>
             {select colors model.MinuteHandColor (MinuteHandColor >> dispatch)}
         </div>
     """

--- a/sample/src/Clock.fs
+++ b/sample/src/Clock.fs
@@ -144,9 +144,9 @@ let styles() =
 
 [<LitElement("my-clock")>]
 let Clock() =
-    let props = LitEl.init({| hourColor = Prop "lightgreen" |}, styles())
+    let props = LitEl.init<{| hourColor: string; internalState |}>([ "hourColor", [CustomAttribute "hour-color"] ], styles())
     let model, dispatch = Hook.useElmish(init, update)
-    view props.hourColor.Value model dispatch
+    view props.hourColor model dispatch
 
 // Make sure this file is being called by the app entry
 let register() = ()

--- a/sample/src/Clock.fs
+++ b/sample/src/Clock.fs
@@ -6,7 +6,7 @@ open Browser.Types
 open Elmish
 open Lit
 open Helpers
-
+open Fable.Core.JsInterop
 type Model =
     { CurrentTime: DateTime
       IntervalId: int
@@ -144,8 +144,13 @@ let styles() =
 
 [<LitElement("my-clock")>]
 let Clock() =
-    let props = LitEl.init<{| hourColor: string; internalState |}>([ "hourColor", [CustomAttribute "hour-color"] ], styles())
+    let props =
+        LitEl.init<{| hourColor: string; |}>(
+            [ "hourColor", [CustomAttribute "hour-color"; InitialValue "purple"; Reflect ] ],
+            styles()
+        )
     let model, dispatch = Hook.useElmish(init, update)
+    JS.setTimeout (fun () -> props?("hourColor") <- "green") 2000
     view props.hourColor model dispatch
 
 // Make sure this file is being called by the app entry

--- a/src/Lit/LitElement.fs
+++ b/src/Lit/LitElement.fs
@@ -16,34 +16,142 @@ module private LitElementUtil =
 
 open LitElementUtil
 
+/// <summary>
+/// The first parameter is the value from the HTML Attribute
+/// The second parameter is the kind of the property provided in the `type` field of the `Prop` type
+/// This should convert the value from a string to the correct representation of the property type
+/// </summary>
+type FromAttributeConverter = 
+    string option -> obj option -> obj
+
+/// <summary>
+/// The first parameter is the object from the Custom Element
+/// The second parameter is the kind of the property provided in the `type` field of the `Prop` type
+/// This should serialize the object value propperly to a string that can be deserialized back with the `FromAttributeConverter` function
+/// </summary>
+type ToAttributeConverter = 
+    obj option -> obj option -> string
+
+/// <summary>
+/// The first parameter is the old value
+/// The second parameter is the new value
+/// this should return true if the new value is different from the old value
+/// </summary>
+type HasPropertyChanged = 
+    obj -> obj -> bool
+
 type PropConfig =
+    /// <summary>
+    /// JS Constructor to help with value change detection and comparison.
+    /// Indicates the type of the property. This is used only as a hint for the
+    /// `converter` to determine how to convert the attribute
+    /// to/from a property.
+    /// `Boolean`, `String`, `Number`, `Object`, and `Array` should be used.
+    /// </summary>
     abstract ``type``: string with get, set
+    /// <summary>
+    /// Indicates the property becomes an observed attribute.
+    /// the lowercase.
+    /// Indicates the property becomes an observed attribute.
+    /// the string value is observed (e.g 'color-depth').
+    /// </summary>
+    /// <remarks>The value has to be lower-cased and dash-cased due to the HTML Spec.</remarks>
     abstract attribute: U2<string, bool> with get, set
+    /// <summary>
+    /// Indicates the property is internal private state. The
+    /// property should not be set by users. A common
+    /// practice to use a leading `_` in the name. The property is not added to
+    /// `observedAttributes`.
+    /// </summary>
+    abstract state: bool with get, set
+    /// <summary>
+    /// Indicates if the property should reflect to an attribute.
+    /// If `true`, when the property is set, the attribute is set using the
+    /// attribute name determined according to the rules for the `attribute`
+    /// property option and the value of the property converted using the rules
+    /// from the `converter` property option.
+    /// </summary>
+    abstract reflect: bool with get, set
+
+    /// <summary>
+    /// Indicates whether an accessor will be created for this property. By
+    /// default, an accessor will be generated for this property that requests an
+    /// update when set. No accessor will be created, and
+    /// it will be the user's responsibility to call
+    /// `this.requestUpdate(propertyName, oldValue)` to request an update when
+    /// the property changes.
+    /// </summary>
+    abstract noAccessor: bool with get, set
+    /// <summary>
+    /// Indicates how to convert the attribute to/from a property.
+    /// If this value is a function, it is used to convert the attribute value a the property value.
+    /// If it's an object, it can have keys for fromAttribute and toAttribute.
+    /// If no toAttribute function is provided and reflect is set to true,
+    /// the property value is set directly to the attribute. A default converter is used if none is provided;
+    /// it supports Boolean, String, Number, Object, and Array. Note, when a property changes
+    /// and the converter is used to update the attribute,
+    /// the property is never updated again as a result of the attribute changing, and vice versa.
+    /// </summary>
+    abstract converter:
+        U2<{| fromAttribute: FromAttributeConverter
+              toAttribute: ToAttributeConverter |}, FromAttributeConverter> with get, set
+
+    abstract hasChanged: HasPropertyChanged with get, set
 
 type Prop internal (defaultValue: obj, options: obj) =
     member internal _.ToConfig() = defaultValue, options
 
     // Using static member instead of constructor in case we need to inline later
     // (e.g. to get the type of an empty array)
-    static member Of(defaultValue: 'T, ?attribute: string) =
+    /// <summary>
+    /// Creates a property accessor.
+    /// </summary>
+    /// <param name="defaultValue">The initialization Value.</param>
+    /// <param name="attribute">The default value of the property.</param>
+    /// <param name="state">The options for the property.</param>
+    /// <param name="reflect">The options for the property.</param>
+    /// <param name="noAccessor">The options for the property.</param>
+    /// <param name="converter">The options for the property.</param>
+    /// <param name="hasChanged">The options for the property.</param>
+    /// <returns>The property accessor.</returns>
+    static member Of
+        (
+            defaultValue: 'T,
+            ?attribute: string,
+            ?state: bool,
+            ?reflect: bool,
+            ?noAccessor: bool,
+            ?converter: FromAttributeConverter,
+            ?hasChanged: HasPropertyChanged
+        ) =
         let options = jsOptions<PropConfig>(fun o ->
-            let typ =
-                match box defaultValue with
-                | :? string -> Some "String"
-                | :? int | :? float -> Some "Number"
-                // TODO: I'm having issues with boolean attributes,
-                // maybe they're faulty in the current Lit 2 RC?
-                | :? bool -> Some "Boolean"
-                // TODO: JSON-serializable arrays and objects
-                | _ -> None
-
-            typ |> Option.iter (fun v -> o.``type`` <- v)
-            attribute |> Option.iter (fun att ->
-                match att.Trim() with
-                // Let's use empty string to sign no attribute,
-                // although we may need to be more explicit later
-                | null | "" -> o.attribute <- !^false
-                | att -> o.attribute <- !^att)
+            // 
+            match state with
+            | Some true -> o.state <- true
+            | Some false
+            | None ->
+                let typ =
+                    match box defaultValue with
+                    | :? string -> Some "String"
+                    | :? int | :? float -> Some "Number"
+                    // TODO: I'm having issues with boolean attributes,
+                    // maybe they're faulty in the current Lit 2 RC?
+                    | :? bool -> Some "Boolean"
+                    // even for custom types, Lit uses JSON. stringify/parse by default
+                    | _ -> Some "Object"
+                state |> Option.iter (fun s -> o.state <- s)
+                typ |> Option.iter (fun v -> o.``type`` <- v)
+                state |> Option.iter (fun v -> o.state <- v)
+                reflect |> Option.iter (fun v -> o.reflect <- v)
+                noAccessor |> Option.iter (fun v -> o.noAccessor <- v)
+                converter |> Option.iter (fun v -> o.converter <- unbox v)
+                hasChanged |> Option.iter (fun v -> o.hasChanged <- v)
+                attribute |> Option.iter (fun att ->
+                    match att.Trim() with
+                    // Let's use empty string to sign no attribute,
+                    // although we may need to be more explicit later
+                    | null | "" -> o.attribute <- !^false
+                    | att -> o.attribute <- !^att)
         )
         Prop<'T>(defaultValue, options)
 
@@ -121,21 +229,6 @@ type LitElementAttribute(name: string) =
 
     [<Emit("Object.defineProperty($1, $2, { get: $3 })")>]
     member _.defineGetter(target: obj, name: string, f: unit -> 'V) = ()
-
-
-    member _.getLitProperties (properties: ((string * Property list) list)) =
-        createObj
-            [ for (property, configuration) in properties do
-                    property ==> createObj
-                        [ for config in configuration do
-                            match config with
-                            | Internal -> "state" ==> (true :> obj)
-                            | Attribute value -> "attribute" ==> (value :> obj)
-                            | CustomAttribute value -> "attribute" ==> (value :> obj)
-                            | Type value -> "type" ==> value
-                            | Reflect -> "reflect" ==> (true :> obj)
-                            | NoAccessor -> "noAccessor" ==> (true :> obj)
-                            | InitialValue _ -> () ] ]
 
     override this.Decorate(renderFn) =
         if renderFn?length > 0 then

--- a/src/Lit/LitElement.fs
+++ b/src/Lit/LitElement.fs
@@ -107,12 +107,12 @@ type Prop internal (defaultValue: obj, options: obj) =
     /// Creates a property accessor.
     /// </summary>
     /// <param name="defaultValue">The initialization Value.</param>
-    /// <param name="attribute">The default value of the property.</param>
-    /// <param name="state">The options for the property.</param>
-    /// <param name="reflect">The options for the property.</param>
-    /// <param name="noAccessor">The options for the property.</param>
-    /// <param name="converter">The options for the property.</param>
-    /// <param name="hasChanged">The options for the property.</param>
+    /// <param name="attribute">Name of the HTML attribute (e.g. "my-prop").</param>
+    /// <param name="state">Indicates that this is an internal property not part of the public API.</param>
+    /// <param name="reflect">When the property changes, it should reflect it's value back to the HTML Attribute.</param>
+    /// <param name="noAccessor">Prevent Lit from creating an accessor for this property.</param>
+    /// <param name="converter">Provide a facility to convert between attributes and properties.</param>
+    /// <param name="hasChanged">Provide custom Value Change detection.</param>
     /// <returns>The property accessor.</returns>
     static member Of
         (

--- a/src/Lit/LitElement.fs
+++ b/src/Lit/LitElement.fs
@@ -5,16 +5,58 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Browser
 
+type Property =
+    /// <summary>
+    /// The initial value for this property
+    /// </summary>
+    | InitialValue of obj
+    /// <summary>
+    /// Indicates the property is internal private state. The
+    /// property should not be set by users. A common
+    /// practice to use a leading `_` in the name. The property is not added to
+    /// `observedAttributes`.
+    /// </summary>
+    | Internal
+    /// <summary>
+    /// Indicates the property becomes an observed attribute.
+    /// the lowercased property name is observed (e.g. `fooBar` becomes `foobar`).
+    /// </summary>
+    | Attribute of bool
+    /// <summary>
+    /// Indicates the property becomes an observed attribute.
+    /// the string value is observed (e.g 'color-depth').
+    /// </summary>
+    /// <remarks>The value has to be lower-cased and dash-cased due to the HTML Spec.</remarks>
+    | CustomAttribute of string
+    /// Indicates the type of the property. This is used only as a hint for the
+    /// `converter` to determine how to convert the attribute
+    /// to/from a property.
+    /// `Boolean`, `String`, `Number`, `Object`, and `Array` should be used.
+    | Type of obj
+    /// Indicates if the property should reflect to an attribute.
+    /// If `true`, when the property is set, the attribute is set using the
+    /// attribute name determined according to the rules for the `attribute`
+    /// property option and the value of the property converted using the rules
+    /// from the `converter` property option.
+    | Reflect
+    /// Indicates whether an accessor will be created for this property. By
+    /// default, an accessor will be generated for this property that requests an
+    /// update when set. No accessor will be created, and
+    /// it will be the user's responsibility to call
+    /// `this.requestUpdate(propertyName, oldValue)` to request an update when
+    /// the property changes.
+    | NoAccessor
+
 type Prop<'T>(defaultValue: 'T) =
     member _.DefaultValue = defaultValue
     [<Emit("$0")>]
     member _.Value = defaultValue
 
 type ILitElInit =
-    abstract init: props: obj * ?styles: Styles -> obj
+    abstract init: ?props: ((string * Property list) list) * ?styles: Styles -> obj
 
 type LitElInitData =
-    {| props: obj; styles: Styles option |}
+    {| props: ((string * Property list) list) option; styles: Styles option |}
 
 type LitElInit() =
     static member fail() = failwith "LitElement.init must be called on top of the render function"
@@ -22,7 +64,7 @@ type LitElInit() =
     member val data: LitElInitData option = None with get, set
 
     interface ILitElInit with
-        member this.init(props, ?styles) =
+        member this.init(?props, ?styles) =
             this.data <- Some {| props = props; styles = styles |}
             box()
 
@@ -73,6 +115,21 @@ type LitElementAttribute(name: string) =
     [<Emit("Object.defineProperty($1, $2, { get: $3 })")>]
     member _.defineGetter(target: obj, name: string, f: unit -> 'V) = ()
 
+
+    member _.getLitProperties (properties: ((string * Property list) list)) =
+        createObj
+            [ for (property, configuration) in properties do
+                    property ==> createObj
+                        [ for config in configuration do
+                            match config with
+                            | Internal -> "state" ==> (true :> obj)
+                            | Attribute value -> "attribute" ==> (value :> obj)
+                            | CustomAttribute value -> "attribute" ==> (value :> obj)
+                            | Type value -> "type" ==> value
+                            | Reflect -> "reflect" ==> (true :> obj)
+                            | NoAccessor -> "noAccessor" ==> (true :> obj)
+                            | InitialValue _ -> () ] ]
+
     override this.Decorate(renderFn) =
         let init = LitElInit()
         try
@@ -83,20 +140,20 @@ type LitElementAttribute(name: string) =
         | None -> LitElInit.fail()
         | Some data ->
             let propsDic =
-                // TODO: Check all values are of Prop type
-                Option.ofObj data.props
-                |> Option.map (fun props ->
-                    (JS.Constructors.Object.keys(data.props),
-                     JS.Constructors.Object.values(data.props))
-                    ||> Seq.zip
-                    |> dict)
+                data.props
+                |> Option.map this.getLitProperties
 
             let initProps (this: obj) =
-                match propsDic with
+                match data.props with 
                 | None -> ()
-                | Some propsDic ->
-                    propsDic |> Seq.iter(fun (KeyValue(k, p)) ->
-                        this?(k) <- (p :?> Prop<obj>).DefaultValue)
+                | Some data ->
+                    for (property, configuration) in data do
+                        for config in configuration do
+                            match config with
+                            | InitialValue value ->
+                                this?(property) <- value
+                            | _ -> ()
+
 
             let classExpr =
                 emitJsExpr (jsConstructor<LitHookElement>, renderFn, initProps) """class extends $0 {
@@ -108,10 +165,7 @@ type LitElementAttribute(name: string) =
             match propsDic with
             | None -> ()
             | Some propsDic ->
-                this.defineGetter(classExpr, "properties", fun () ->
-                    (obj(), propsDic) ||> Seq.fold (fun o (KeyValue(k, p)) ->
-                        o?(k) <- obj() // TODO: Property settings
-                        o))
+                this.defineGetter(classExpr, "properties", fun () -> propsDic)
 
             match data.styles with
             | None -> ()
@@ -123,6 +177,5 @@ type LitElementAttribute(name: string) =
             box(fun () -> failwith $"{name} is not immediately callable, it must be created in HTML") :?> _
 
 type LitEl =
-    // TODO: Allow unit props
-    static member inline init(props: 'Props, ?styles: Styles) =
-        jsThis<ILitElInit>.init(props, ?styles=styles) :?> 'Props
+    static member inline init<'Props>(?props: list<string * list<Property>>, ?styles: Styles) =
+        jsThis<ILitElInit>.init(?props = props, ?styles=styles) :?> 'Props


### PR DESCRIPTION
Following from https://github.com/alfonsogarciacaro/Fable.Lit/pull/7#issuecomment-916669138
I like the decorator approach, my mind still bends a little but I think I'm getting the hang of it.

I went ahead and tried to add part of the configurable parts of the properties to match Lit's API I'm still not sure how to make it as seamless as it was with your changes, but this also will allow authors to work with internal state properties or at least react to them when external sources set a property plus removing the limitation that attributes are strings only


**Edit**: kudos for the styles that go directly to the static property this will help with performance for project wide shared styles